### PR TITLE
Additional node details

### DIFF
--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -272,6 +272,14 @@ class Session:
                     name,
                     node["role"],
                     node["phase"],
+                    next(
+                        (
+                            size.id
+                            for size in sizes
+                            if size.name == node["size"]
+                        ),
+                        None
+                    ),
                     node.get("ip"),
                     node.get("kubeletVersion"),
                     node.get("nodeGroup"),

--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -274,7 +274,8 @@ class Session:
                     node["phase"],
                     node.get("ip"),
                     node.get("kubeletVersion"),
-                    node.get("nodeGroup")
+                    node.get("nodeGroup"),
+                    dateutil.parser.parse(node["created"])
                 )
                 for name, node in cluster.get("status", {}).get("nodes", {}).items()
             ],

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -58,6 +58,8 @@ class Node:
     kubelet_version: t.Optional[str]
     #: The node group of the node
     node_group: t.Optional[str]
+    #: The time at which the node was created
+    created_at: datetime.datetime
 
 
 @dataclasses.dataclass(frozen = True)

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -52,6 +52,8 @@ class Node:
     role: str
     #: The status of the node
     status: str
+    #: The id of the size of the node
+    size_id: str
     #: The internal IP of the node
     ip: t.Optional[str]
     #: The kubelet version of the node

--- a/api/azimuth/serializers.py
+++ b/api/azimuth/serializers.py
@@ -580,8 +580,10 @@ class KubernetesClusterNodeGroupSerializer(
     machine_size = SizeRefSerializer(source = "machine_size_id", read_only = True)
 
 
-class KubernetesClusterNodeSerializer(make_dto_serializer(capi_dto.Node)):
-    pass
+class KubernetesClusterNodeSerializer(
+    make_dto_serializer(capi_dto.Node, exclude = ["size_id"])
+):
+    size = SizeRefSerializer(source = "size_id", read_only = True)
 
 
 class KubernetesClusterAddonSerializer(make_dto_serializer(capi_dto.Addon)):

--- a/ui/src/components/pages/tenancy/kubernetes-clusters/table.js
+++ b/ui/src/components/pages/tenancy/kubernetes-clusters/table.js
@@ -404,6 +404,7 @@ const NodesTable = ({ kubernetesCluster, sizes }) => {
                     <th>Size</th>
                     <th>Kubelet Version</th>
                     <th>IP address</th>
+                    <th>Age</th>
                 </tr>
             </thead>
             <tbody>
@@ -431,6 +432,7 @@ const NodesTable = ({ kubernetesCluster, sizes }) => {
                         </td>
                         <td>{node.kubelet_version || '-'}</td>
                         <td>{node.ip || '-'}</td>
+                        <td>{moment(node.created_at).fromNow(true)}</td>
                     </tr>
                 ))}
             </tbody>

--- a/ui/src/components/pages/tenancy/kubernetes-clusters/table.js
+++ b/ui/src/components/pages/tenancy/kubernetes-clusters/table.js
@@ -190,19 +190,6 @@ const statusStyles = {
 };
 
 
-const NodeSizeLink = ({ kubernetesCluster, node, sizes }) => {
-    let sizeId;
-    if( node.role === "control-plane" ) {
-        sizeId = kubernetesCluster.control_plane_size.id;
-    }
-    else {
-        const nodeGroup = kubernetesCluster.node_groups.find(ng => ng.name === node.node_group);
-        sizeId = get(nodeGroup, ['machine_size', 'id']);
-    }
-    return <MachineSizeLink sizes={sizes} sizeId={sizeId} />;
-};
-
-
 const ClusterOverviewCard = ({ kubernetesCluster, kubernetesClusterTemplates }) => (
     <Card className="mb-3">
         <Card.Header className="text-center">Cluster details</Card.Header>
@@ -424,11 +411,7 @@ const NodesTable = ({ kubernetesCluster, sizes }) => {
                             />
                         </td>
                         <td>
-                            <NodeSizeLink
-                                kubernetesCluster={kubernetesCluster}
-                                node={node}
-                                sizes={sizes}
-                            />
+                            <MachineSizeLink sizes={sizes} sizeId={node.size.id} />
                         </td>
                         <td>{node.kubelet_version || '-'}</td>
                         <td>{node.ip || '-'}</td>


### PR DESCRIPTION
1. Created time for nodes
2. Node-specific size

Previously, nodes did not have their size associated directly and the size was pulled from the node group. This meant that node size was reported incorrectly for existing nodes (until they were replaced) when the size associated with a node group was changed.