### PR TITLE
Amend help text

### DIFF
--- a/ui/src/components/pages/tenancy/platforms/clusters/form.js
+++ b/ui/src/components/pages/tenancy/platforms/clusters/form.js
@@ -97,7 +97,7 @@ export const ClusterForm = ({
             <Field
                 name="name"
                 label="Platform name"
-                helpText="Must contain lower-case alphanumeric characters and dash (-) only."
+                helpText="Must start with a letter, and only contain lower-case alphanumeric characters & dashes (-)."
             >
                 <BSForm.Control
                     type="text"

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/form.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/form.js
@@ -106,7 +106,7 @@ const NodeGroupModalForm = ({
                     <Field
                         name="name"
                         label="Name"
-                        helpText="Must contain lower-case alphanumeric characters and dash (-) only."
+                        helpText="Must start with a letter, and only contain lower-case alphanumeric characters & dashes (-)."
                     >
                         <BSForm.Control
                             as={InputWithCustomValidity}
@@ -347,7 +347,7 @@ export const KubernetesClusterForm = ({
                 <Field
                     name="name"
                     label="Cluster name"
-                    helpText="Must contain lower-case alphanumeric characters and dash (-) only."
+                    helpText="Must start with a letter, and only contain lower-case alphanumeric characters & dashes (-)."
                 >
                     <BSForm.Control
                         type="text"

--- a/ui/src/components/pages/tenancy/platforms/kubernetes_apps/form.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes_apps/form.js
@@ -205,7 +205,7 @@ export const KubernetesAppForm = ({
             <Field
                 name="name"
                 label="Platform name"
-                helpText="Must contain lower-case alphanumeric characters and dash (-) only."
+                helpText="Must start with a letter, and only contain lower-case alphanumeric characters & dashes (-)."
             >
                 <BSForm.Control
                     type="text"


### PR DESCRIPTION
Kubernetes rerquires names start with a lowercase letter. Added this as a requirement in the help text for the platform name.