### PR TITLE
Filter status endpoint from access logs + stats

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,9 +28,6 @@ RUN pip install --no-cache-dir \
       'whitenoise==5.3.0' \
       'git+https://github.com/stackhpc/django-flexi-settings.git@079359cc1e2d380a15ae6149ebffbcdae8094276#egg=django_flexi_settings'
 
-# Install Gunicorn config
-COPY ./etc/gunicorn /etc/gunicorn
-
 # Install dependencies
 # Doing this separately by copying only the requirements file enables better use of the build cache
 COPY ./requirements.txt /application/
@@ -39,6 +36,9 @@ RUN pip install --no-deps --requirement /application/requirements.txt
 # Install the application itself
 COPY . /application
 RUN pip install --no-deps -e /application
+
+# Install Gunicorn config
+COPY ./etc/gunicorn /etc/gunicorn
 
 # Install application configuration using flexi-settings
 ENV DJANGO_SETTINGS_MODULE flexi_settings.settings
@@ -56,4 +56,4 @@ COPY ./bin /usr/local/bin
 EXPOSE 8080
 USER $APP_UID
 ENTRYPOINT ["tini", "-g", "--", "azimuth-entrypoint"]
-CMD ["gunicorn", "--config", "/etc/gunicorn/conf.py", "azimuth_site.wsgi:application", "--statsd-host", "localhost:9125", "--statsd-prefix", "azimuth-api"]
+CMD ["gunicorn", "--config", "/etc/gunicorn/conf.py", "azimuth_site.wsgi:application"]

--- a/api/azimuth_site/gunicorn.py
+++ b/api/azimuth_site/gunicorn.py
@@ -1,0 +1,26 @@
+from gunicorn.glogging import Logger as GLogger
+from gunicorn.instrument.statsd import Statsd
+
+from django.urls import reverse
+
+
+class StatusEndpointFilterMixin:
+    """
+    Mixin for logger classes that allows for the filtering of the status endpoint.
+    """
+    def access(self, resp, req, environ, request_time):
+        # If the request path starts with the status path, ignore it
+        if not req.path.startswith(reverse("status")):
+            super().access(resp, req, environ, request_time)
+
+
+class Logger(StatusEndpointFilterMixin, GLogger):
+    """
+    Custom logger that allows for the filtering of the status endpoint.
+    """
+
+
+class StatsdLogger(StatusEndpointFilterMixin, Statsd):
+    """
+    Custom statsd-enabled logger that allows for the filtering of the status endpoint.
+    """

--- a/api/etc/gunicorn/conf.py
+++ b/api/etc/gunicorn/conf.py
@@ -4,6 +4,9 @@
 import multiprocessing
 import os
 
+from azimuth_site.gunicorn import Logger, StatsdLogger
+
+
 # Configure the bind address
 _host = os.environ.get("GUNICORN_HOST", "0.0.0.0")
 _port = os.environ.get("GUNICORN_PORT", "8080")
@@ -20,7 +23,14 @@ workers = int(os.environ.get("GUNICORN_WORKERS", str(max(cores, 2))))
 threads = int(os.environ.get("GUNICORN_THREADS", str(int((4 * cores) / workers))))
 worker_class = os.environ.get("GUNICORN_WORKER_CLASS", "gthread")
 
+# Configure statsd
+statsd_host = os.environ.get("GUNICORN_STATSD_HOST")
+statsd_prefix = os.environ.get("GUNICORN_STATSD_PREFIX", "azimuth-api")
+
 # Configure logging
+# We use a custom logging class that filters out the health checks for stats and access logs
+_logger_class = StatsdLogger if statsd_host else Logger
+logger_class = ".".join([_logger_class.__module__, _logger_class.__qualname__])
 loglevel = os.environ.get("GUNICORN_LOGLEVEL", "info")
 errorlog = "-"
 # Access logging on by default

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,35 +1,35 @@
-anyio==3.5.0
-asgiref==3.5.1
-attrs==22.1.0
-certifi==2021.10.8
-cffi==1.15.0
-charset-normalizer==2.0.12
-cryptography==37.0.2
-Django==4.0.4
+anyio==3.6.2
+asgiref==3.6.0
+attrs==22.2.0
+certifi==2022.12.7
+cffi==1.15.1
+charset-normalizer==3.0.1
+cryptography==39.0.1
+Django==4.1.7
 django-settings-object @ git+https://github.com/cedadev/django-settings-object.git@2b66c0fc5eae92972df5210b4bc43f7d95ad9ceb
-djangorestframework==3.13.1
-docutils==0.18.1
-easykube @ git+https://github.com/stackhpc/easykube.git@714c9d4ebbda99cb0aef88e4e9d40cb9495860d9
-h11==0.12.0
-httpcore==0.14.7
-httpx==0.22.0
-idna==3.3
+djangorestframework==3.14.0
+docutils==0.19
+easykube @ git+https://github.com/stackhpc/easykube.git@bf6e154736b7e8c541743911e9774fa5268889b5
+h11==0.14.0
+httpcore==0.16.3
+httpx==0.23.3
+idna==3.4
 jasmin-ldap @ git+https://github.com/cedadev/jasmin-ldap.git@3e1d2659731e9e1a65e8723b4e72c776ae7f7b25
 Jinja2==3.1.2
-jsonschema==4.16.0
+jsonschema==4.17.3
 ldap3==2.9.1
-MarkupSafe==2.1.1
+MarkupSafe==2.1.2
 pyasn1==0.4.8
 pycparser==2.21
-pyrsistent==0.18.1
+pyrsistent==0.19.3
 python-dateutil==2.8.2
-pytz==2022.1
+pytz==2022.7.1
 PyYAML==6.0
 rackit @ git+https://github.com/stackhpc/rackit.git@cb2da480f9fc99f36cc777d58dfbccec33434879
-requests==2.27.1
+requests==2.28.2
 rfc3986==1.5.0
 six==1.16.0
-sniffio==1.2.0
-sqlparse==0.4.2
-urllib3==1.26.9
+sniffio==1.3.0
+sqlparse==0.4.3
+urllib3==1.26.14
 voluptuous==0.13.1

--- a/chart/templates/api/deployment.yaml
+++ b/chart/templates/api/deployment.yaml
@@ -50,8 +50,9 @@ spec:
           securityContext: {{ toYaml $values.securityContext | nindent 12 }}
           image: {{ printf "%s:%s" $values.image.repository (default .Chart.AppVersion $values.image.tag) }}
           imagePullPolicy: {{ $values.image.pullPolicy }}
-          {{- if (and .Values.tags.clusters (eq $clusterEngine.type "awx")) }}
+          {{- if or $values.monitoring.enabled (and .Values.tags.clusters (eq $clusterEngine.type "awx")) }}
           env:
+            {{- if and .Values.tags.clusters (eq $clusterEngine.type "awx") }}
             - name: AWX_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -63,6 +64,11 @@ spec:
                 secretKeyRef:
                   name: {{ quote . }}
                   key: password
+            {{- end }}
+            {{- end }}
+            {{- if $values.monitoring.enabled }}
+            - name: GUNICORN_STATSD_HOST
+              value: "localhost:9125"
             {{- end }}
           {{- end }}
           ports:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -20,7 +20,7 @@ source ./venv/bin/activate
 pip install git+https://github.com/cedadev/django-settings-object.git
 pip install git+https://github.com/stackhpc/easykube.git
 pip install git+https://github.com/cedadev/jasmin-ldap.git
-pip install git+https://github.com/cedadev/rackit.git
+pip install git+https://github.com/stackhpc/rackit.git
 pip install -e ./api
 ```
 


### PR DESCRIPTION
With the current metrics gathering implementation, the stats are dominated by the status check and the access log is hard to read due to the number of entries for the status check.

<img width="685" alt="Screenshot 2023-03-01 at 14 37 00" src="https://user-images.githubusercontent.com/642657/222171758-b2a57e65-c1fe-408a-b212-91c9a0a2a9c5.png">

This PR implements a custom logger that excludes the status check endpoint from access logs and stats gathering.