### PR TITLE
Changes to allow automated testing

### DIFF
--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -162,6 +162,7 @@ class Session:
             ct.spec.get("description"),
             ct.spec["values"]["kubernetesVersion"],
             ct.spec.get("deprecated", False),
+            ct.spec.get("tags", []),
             dateutil.parser.parse(ct.metadata["creationTimestamp"]),
         )
 

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -18,6 +18,8 @@ class ClusterTemplate:
     kubernetes_version: str
     #: Indicates if this is a deprecated template
     deprecated: bool
+    #: The tags for the template
+    tags: t.List[str]
     #: The datetime at which the template was created
     created_at: datetime.datetime
 

--- a/api/azimuth/middleware.py
+++ b/api/azimuth/middleware.py
@@ -2,9 +2,6 @@
 Django middleware for restoring the cloud provider.
 """
 
-from .provider import errors
-from .settings import cloud_settings
-
 
 class CleanupProviderMiddleware:
     """

--- a/api/azimuth/provider/openstack/provider.py
+++ b/api/azimuth/provider/openstack/provider.py
@@ -1378,15 +1378,6 @@ class ScopedSession(base.ScopedSession):
             for k, v in cluster.parameter_values.items()
             if k not in {"cluster_floating_network", "cluster_network"}
         }
-        # Add any tags attached to the stack
-        try:
-            stack = self._connection.orchestration.stacks.find_by_stack_name(cluster.name)
-        except (api.ServiceNotSupported, rackit.NotFound):
-            tags = cluster.tags
-        else:
-            tags = list(cluster.tags)
-            if stack:
-                tags.extend(stack.tags or [])
         original_error = (cluster.error_message or "").lower()
         # Convert quota-related error messages based on known OpenStack errors
         if any(m in original_error for m in {"quota exceeded", "exceedsavailablequota"}):
@@ -1407,7 +1398,6 @@ class ScopedSession(base.ScopedSession):
         return dataclasses.replace(
             cluster,
             parameter_values = params,
-            tags = tags,
             error_message = error_message
         )
 

--- a/api/azimuth/views.py
+++ b/api/azimuth/views.py
@@ -786,19 +786,19 @@ def external_ips(request, tenant):
         return response.Response(serializer.data)
 
 
-@provider_api_view(["GET", "PUT"])
+@provider_api_view(["GET", "PATCH"])
 def external_ip_details(request, tenant, ip):
     """
     On ``GET`` requests, return the details for the external IP address.
 
-    On ``PUT`` requests, attach the specified machine to the external IP address.
+    On ``PATCH`` requests, attach the specified machine to the external IP address.
     If the machine_id is ``null``, the external IP address will be detached from
     the machine it is currently attached to.
     The request body should contain the machine ID::
 
         { "machine_id": "<machine id>" }
     """
-    if request.method == "PUT":
+    if request.method == "PATCH":
         input_serializer = serializers.ExternalIPSerializer(data = request.data)
         input_serializer.is_valid(raise_exception = True)
         machine_id = input_serializer.validated_data["machine_id"]
@@ -867,12 +867,12 @@ def volumes(request, tenant):
         return response.Response(serializer.data)
 
 
-@provider_api_view(["GET", "PUT", "DELETE"])
+@provider_api_view(["GET", "PATCH", "DELETE"])
 def volume_details(request, tenant, volume):
     """
     On ``GET`` requests, return the details for the specified volume.
 
-    On ``PUT`` requests, update the attachment status of the specified volume
+    On ``PATCH`` requests, update the attachment status of the specified volume
     depending on the given ``machine_id``.
 
     To attach a volume to a machine, just give the machine id::
@@ -885,7 +885,7 @@ def volume_details(request, tenant, volume):
 
     On ``DELETE`` requests, delete the specified volume.
     """
-    if request.method == "PUT":
+    if request.method == "PATCH":
         input_serializer = serializers.UpdateVolumeSerializer(data = request.data)
         input_serializer.is_valid(raise_exception = True)
         machine_id = input_serializer.validated_data["machine_id"]
@@ -1023,12 +1023,12 @@ def clusters(request, tenant):
                 return response.Response(serializer.data)
 
 
-@provider_api_view(["GET", "PUT", "DELETE"])
+@provider_api_view(["GET", "PATCH", "DELETE"])
 def cluster_details(request, tenant, cluster):
     """
     On ``GET`` requests, return the named cluster.
 
-    On ``PUT`` requests, update the named cluster with the given paramters.
+    On ``PATCH`` requests, update the named cluster with the given paramters.
 
     On ``DELETE`` requests, delete the named cluster.
     """
@@ -1043,7 +1043,7 @@ def cluster_details(request, tenant, cluster):
     with request.auth.scoped_session(tenant) as session:
         with cloud_settings.CLUSTER_ENGINE.create_manager(session) as cluster_manager:
             cluster = cluster_manager.find_cluster(cluster)
-            if request.method == "PUT":
+            if request.method == "PATCH":
                 input_serializer = serializers.UpdateClusterSerializer(
                     data = request.data,
                     context = dict(

--- a/api/azimuth_auth/authenticator/base.py
+++ b/api/azimuth_auth/authenticator/base.py
@@ -20,6 +20,22 @@ class BaseAuthenticator:
     #:   https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
     uses_crossdomain_post_requests = False
 
+    #: Indicates if the authenticator should only be used in interactive flows, e.g.
+    #: if a browser is required in order to complete the authentication
+    interactive_only = False
+
+    def get_representation(self):
+        """
+        Returns a dictionary representation of the authenticator, for use in the SDK.
+        """
+        if hasattr(self, "authenticator_type"):
+            return {
+                "type": self.authenticator_type,
+                "options": self.get_options(),
+            }
+        else:
+            raise NotImplementedError
+
     def get_options(self):
         """
         Allows the authenticator to contribute multiple options to the authenticator
@@ -55,5 +71,13 @@ class BaseAuthenticator:
         successful or None if not.
 
         This method may receive GET or POST requests depending on the implementation.
+        """
+        raise NotImplementedError
+
+    def auth_token(self, auth_data):
+        """
+        Use the given auth data to attempt to obtain a token.
+
+        Returns the token if successful, None if not..
         """
         raise NotImplementedError

--- a/api/azimuth_auth/authenticator/form.py
+++ b/api/azimuth_auth/authenticator/form.py
@@ -32,14 +32,6 @@ class FormAuthenticator(BaseAuthenticator):
         """
         return self.form_class(*args, **kwargs)
 
-    def authenticate(self, form_data):
-        """
-        Given the data from a successful form validation, attempt an authentication.
-
-        Should return a token if the authentication is successful, None otherwise.
-        """
-        raise NotImplementedError
-
     def auth_start(self, request, auth_complete_url, selected_option = None):
         # Just render an empty form
         return render(
@@ -61,4 +53,4 @@ class FormAuthenticator(BaseAuthenticator):
         if not form.is_valid():
             return
         # If the form data is valid, attempt an authentication
-        return self.authenticate(form.cleaned_data)
+        return self.auth_token(form.cleaned_data)

--- a/api/azimuth_auth/authenticator/openstack.py
+++ b/api/azimuth_auth/authenticator/openstack.py
@@ -28,10 +28,16 @@ class OpenStackFormAuthenticator(FormAuthenticator):
         raise NotImplementedError
 
     def auth_token(self, auth_data):
+        # Try to get the identity data from the provided auth data
+        # If the required data is not present, a KeyError will be raised
+        try:
+            identity = self.get_identity(auth_data)
+        except KeyError:
+            return None
         # Authenticate the user by submitting an appropriate request to the token URL
         response = requests.post(
             self.token_url,
-            json = dict(auth = dict(identity = self.get_identity(auth_data))),
+            json = dict(auth = dict(identity = identity)),
             verify = self.verify_ssl
         )
         # If the response is a success, return the token

--- a/api/azimuth_auth/authenticator/openstack.py
+++ b/api/azimuth_auth/authenticator/openstack.py
@@ -21,17 +21,17 @@ class OpenStackFormAuthenticator(FormAuthenticator):
         self.token_url = f"{self.auth_url}/auth/tokens"
         self.verify_ssl = verify_ssl
 
-    def get_identity(self, form_data):
+    def get_identity(self, auth_data):
         """
         Returns the identity to use for the token request, derived from the form data.
         """
         raise NotImplementedError
 
-    def authenticate(self, form_data):
+    def auth_token(self, auth_data):
         # Authenticate the user by submitting an appropriate request to the token URL
         response = requests.post(
             self.token_url,
-            json = dict(auth = dict(identity = self.get_identity(form_data))),
+            json = dict(auth = dict(identity = self.get_identity(auth_data))),
             verify = self.verify_ssl
         )
         # If the response is a success, return the token
@@ -49,18 +49,20 @@ class PasswordAuthenticator(OpenStackFormAuthenticator):
     Authenticator that authenticates with an OpenStack cloud using the
     password authentication method.
     """
+    authenticator_type = "openstack_password"
+
     def __init__(self, auth_url, domain = 'default', verify_ssl = True):
         super().__init__(auth_url, verify_ssl)
         self.domain = domain
 
-    def get_identity(self, form_data):
+    def get_identity(self, auth_data):
         return dict(
             methods = ['password'],
             password = dict(
                 user = dict(
                     domain = dict(name = self.domain),
-                    name = form_data['username'],
-                    password = form_data['password']
+                    name = auth_data['username'],
+                    password = auth_data['password']
                 )
             )
         )
@@ -78,14 +80,16 @@ class ApplicationCredentialAuthenticator(OpenStackFormAuthenticator):
     """
     Authenticator that authenticates with an OpenStack cloud using an application credential.
     """
+    authenticator_type = "openstack_application_credential"
+
     form_class = ApplicationCredentialForm
 
-    def get_identity(self, form_data):
+    def get_identity(self, auth_data):
         return dict(
             methods = ['application_credential'],
             application_credential = dict(
-                id = form_data['application_credential_id'],
-                secret = form_data['application_credential_secret']
+                id = auth_data['application_credential_id'],
+                secret = auth_data['application_credential_secret']
             )
         )
 
@@ -104,6 +108,8 @@ class FederatedAuthenticator(RedirectAuthenticator):
         "{auth_url}/auth/OS-FEDERATION/identity_providers/{provider}/protocols/{protocol}/websso"
     )
     PROTOCOL_ONLY_TPL = "{auth_url}/auth/OS-FEDERATION/websso/{protocol}"
+
+    authenticator_type = "openstack_federation"
 
     uses_crossdomain_post_requests = True
 

--- a/api/azimuth_auth/authenticator/redirect.py
+++ b/api/azimuth_auth/authenticator/redirect.py
@@ -16,6 +16,9 @@ class RedirectAuthenticator(BaseAuthenticator):
     Its main purpose is to ensure that we can break a redirection loop when an
     authentication fails.
     """
+    # Authentications that begin with a redirect require a browser
+    interactive_only = True
+
     failure_code = "external_auth_failed"
     failure_template = "azimuth_auth/external_auth_failed.html"
 

--- a/api/azimuth_auth/forms.py
+++ b/api/azimuth_auth/forms.py
@@ -13,6 +13,11 @@ def authenticator_choices():
     """
     for authenticator in auth_settings.AUTHENTICATORS:
         name = authenticator["NAME"]
+        # Allow authenticators to be hidden from selection
+        # They will still be available if the user knows the link
+        # In particular, this is used for the appcred authenticator
+        if authenticator.get("HIDDEN", False):
+            continue
         options = authenticator["AUTHENTICATOR"].get_options()
         if options:
             for option, option_label in options:

--- a/api/azimuth_auth/middleware.py
+++ b/api/azimuth_auth/middleware.py
@@ -2,15 +2,7 @@
 Django middlewares for the Azimuth auth package.
 """
 
-from datetime import datetime, timedelta
-import logging
-
-from dateutil import parser, tz
-
 from .settings import auth_settings
-
-
-logger = logging.getLogger(__name__)
 
 
 class BaseMiddleware:

--- a/api/azimuth_auth/templatetags/azimuth_auth_tags.py
+++ b/api/azimuth_auth/templatetags/azimuth_auth_tags.py
@@ -6,6 +6,7 @@ from django import template
 from django.urls import reverse
 
 from ..settings import auth_settings
+from ..forms import authenticator_choices
 
 
 register = template.Library()
@@ -29,7 +30,7 @@ def change_auth_button(context):
             reverse('azimuth_auth:login'),
             auth_settings.CHANGE_METHOD_PARAM
         ),
-        'render_button': len(auth_settings.AUTHENTICATORS) > 1,
+        'render_button': len(list(authenticator_choices())) > 1,
     }
 
 

--- a/api/azimuth_auth/urls.py
+++ b/api/azimuth_auth/urls.py
@@ -9,8 +9,10 @@ from . import views
 
 app_name = 'azimuth_auth'
 urlpatterns = [
+    path('authenticators/', views.authenticators, name = 'authenticators'),
     path('login/', views.login, name = 'login'),
     path('<slug:authenticator>/start/', views.start, name = 'start'),
     path('<slug:authenticator>/complete/', views.complete, name = 'complete'),
+    path('<slug:authenticator>/token/', views.token, name = 'token'),
     path('logout/', views.logout, name = 'logout'),
 ]

--- a/api/etc/azimuth/app.py
+++ b/api/etc/azimuth/app.py
@@ -30,6 +30,9 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'azimuth_auth.middleware.BearerTokenMiddleware',
+    # Include the session middleware after the bearer token middleware
+    # so that the session takes precedence when it is available
     'azimuth_auth.middleware.SessionTokenMiddleware',
     'azimuth.middleware.CleanupProviderMiddleware',
 ]

--- a/chart/files/api/settings/03-cloud-authenticators.yaml
+++ b/chart/files/api/settings/03-cloud-authenticators.yaml
@@ -8,6 +8,9 @@ AZIMUTH_AUTH:
       {{- with .label }}
       LABEL: {{ quote . }}
       {{- end }}
+      {{- with .hidden }}
+      HIDDEN: true
+      {{- end }}
       AUTHENTICATOR:
         {{- if (eq .type "openstack-password") }}
         FACTORY: azimuth_auth.authenticator.openstack.PasswordAuthenticator

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -192,6 +192,8 @@ authenticators: []
   #   name: password
   #   # The human-readable name for the authenticator (defaults to name if not given)
   #   label: Username + Password
+  #   # Indicates whether the authenticator should be hidden from users
+  #   hidden: true
   #   # The type of authenticator to use
   #   # Currently only openstack-{password,application-credential,federation} are supported
   #   type: openstack-password

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -482,7 +482,7 @@ const UpdateKubernetesClusterButton = ({
     const handleSubmit = data => {
         // Remove the name and template from the data for an update
         const { name, template, ...patchData } = data;
-        kubernetesClusterActions.update(patchData, true);
+        kubernetesClusterActions.update(patchData);
         setInFlight(true);
         close();
     };

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/upgrade-modal.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/upgrade-modal.js
@@ -39,7 +39,7 @@ export const UpgradeKubernetesClusterButton = ({
 
     const handleSubmit = (evt) => {
         evt.preventDefault();
-        kubernetesClusterActions.update({ template }, true);
+        kubernetesClusterActions.update({ template });
         setInFlight(true);
         close();
     };

--- a/ui/src/components/pages/tenancy/platforms/kubernetes_apps/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes_apps/card.js
@@ -355,7 +355,7 @@ const KubernetesAppDetailsButton = ({
                                 tenancy={tenancy}
                                 tenancyActions={tenancyActions}
                                 disabled={inFlight || working}
-                                onSubmit={data => kubernetesAppActions.update(data, true)}
+                                onSubmit={kubernetesAppActions.update}
                                 className="me-2"
                             />
                             <PlatformDeleteButton

--- a/ui/src/redux/session.js
+++ b/ui/src/redux/session.js
@@ -122,8 +122,8 @@ function apiRequestEpic(action$) {
                 const method = options.method || 'GET';
                 // Make sure we ask for JSON
                 const headers = { 'Content-Type': 'application/json' };
-                // For POST/PUT/DELETE, include the CSRF token if present
-                if( ['POST', 'PUT', 'DELETE'].includes(method.toUpperCase()) ) {
+                // For POST/PATCH/PUT/DELETE, include the CSRF token if present
+                if( ['POST', 'PATCH', 'PUT', 'DELETE'].includes(method.toUpperCase()) ) {
                     const csrfToken = Cookies.get('csrftoken');
                     if( csrfToken ) headers['X-CSRFToken'] = csrfToken;
                 }

--- a/ui/src/redux/tenancies/resource.js
+++ b/ui/src/redux/tenancies/resource.js
@@ -78,7 +78,7 @@ export function createActionCreators(resourceName, actions) {
                 body: data || {}
             }
         }),
-        update: (tenancyId, resourceId, data, partial = false) => ({
+        update: (tenancyId, resourceId, data) => ({
             type: actions.UPDATE,
             tenancyId,
             resourceId,
@@ -87,7 +87,7 @@ export function createActionCreators(resourceName, actions) {
             failureAction: actions.UPDATE_FAILED,
             options: {
                 url: `/api/tenancies/${tenancyId}/${resource}s/${resourceId}/`,
-                method: partial ? 'PATCH' : 'PUT',
+                method: 'PATCH',
                 body: data
             }
         }),


### PR DESCRIPTION
This patch focuses mostly on making the authentication discoverable and usable programatically.

While developing the Azimuth SDK, using the REST client from [easykube](https://github.com/stackhpc/easykube), it became apparent that the semantics of the Azimuth API were wrong in that it was accepting partial updates using `PUT`. As such, this patch includes a change in the semantics of the API to correctly use `PATCH` requests for those updates and the corresponding UI changes.

It also includes adding tags to Kubernetes templates to allow for better programmatic filtering in the presence of custom templates.