### PR TITLE
Enable local UI in Tilt dev environment

### DIFF
--- a/tilt-component.yaml
+++ b/tilt-component.yaml
@@ -1,3 +1,16 @@
+#####
+# NOTE
+#
+# The build/push/deploy cycle doesn't really work for UI development as the
+# feedback cycle is too slow - this is because even a change to a single file
+# triggers a whole production rebuild including obfuscation, tree-shaking etc.
+#
+# Instead of changing the container build, which is what we want for prod, we
+# instead set up a port forward for the Azimuth API and run the UI locally using
+# a local_resource
+# #####
+
+
 chart: ./chart
 
 images:
@@ -5,6 +18,17 @@ images:
     context: ./api
     chart_path: api.image
 
+port_forwards:
+  - kind: service
+    name: azimuth-api
+    port: "8000:80"
+
+local_resources:
   azimuth-ui:
-    context: ./ui
-    chart_path: ui.image
+    serve_cmd:
+      - yarn
+      - --cwd
+      - ./ui
+      - serve
+    links:
+      - http://localhost:3000

--- a/tilt-component.yaml
+++ b/tilt-component.yaml
@@ -18,6 +18,10 @@ images:
     context: ./api
     chart_path: api.image
 
+  azimuth-ui:
+    context: ./ui
+    chart_path: ui.image
+
 port_forwards:
   - kind: service
     name: azimuth-api

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/ui/webpack.dev.js
+++ b/ui/webpack.dev.js
@@ -23,8 +23,7 @@ module.exports = merge(
                 {
                     context: ['/api', '/auth', '/static'],
                     target: 'http://127.0.0.1:8000',
-                    changeOrigin: true,
-                    xfwd: true
+                    changeOrigin: false
                 }
             ]
         }


### PR DESCRIPTION
The feedback cycle for UI development is too slow if we have to wait for a production build of the UI.

This PR adds support for running the UI locally for development, reaching out to the Azimuth API on the dev cluster via a port forward.