### PR TITLE
Record username and user_id for all clusters

### DIFF
--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -304,7 +304,6 @@ class Session:
             cluster.spec.get("createdByUserId"),
             cluster.spec.get("updatedByUsername"),
             cluster.spec.get("updatedByUserId"),
-            cluster.spec.get("createdByUserId") == user_id,
         )
 
     @convert_exceptions

--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -196,7 +196,7 @@ class Session:
                 .fetch(id)
         )
 
-    def _from_api_cluster(self, cluster, sizes):
+    def _from_api_cluster(self, cluster, sizes, user_id):
         """
         Converts a cluster from the Kubernetes API to a DTO.
         """
@@ -304,6 +304,7 @@ class Session:
             cluster.spec.get("createdByUserId"),
             cluster.spec.get("updatedByUsername"),
             cluster.spec.get("updatedByUserId"),
+            cluster.spec.get("createdByUserId") == user_id,
         )
 
     @convert_exceptions
@@ -321,7 +322,8 @@ class Session:
         self._log("Found %s clusters", len(clusters))
         if clusters:
             sizes = list(self._cloud_session.sizes())
-            return tuple(self._from_api_cluster(c, sizes) for c in clusters)
+            user_id = self._cloud_session.user_id()
+            return tuple(self._from_api_cluster(c, sizes, user_id) for c in clusters)
         else:
             return ()
 
@@ -338,7 +340,8 @@ class Session:
                 .fetch(id)
         )
         sizes = list(self._cloud_session.sizes())
-        return self._from_api_cluster(cluster, sizes)
+        user_id = self._cloud_session.user_id()
+        return self._from_api_cluster(cluster, sizes, user_id)
 
     def _create_credential(self, cluster_name):
         """
@@ -472,7 +475,8 @@ class Session:
         })
         # Use the sizes that we already have
         sizes = [control_plane_size] + [ng["machine_size"] for ng in node_groups]
-        return self._from_api_cluster(cluster, sizes)
+        user_id = self._cloud_session.user_id()
+        return self._from_api_cluster(cluster, sizes, user_id)
 
     @convert_exceptions
     def update_cluster(self, cluster: t.Union[dto.Cluster, str], **options):
@@ -489,7 +493,8 @@ class Session:
                 .patch(cluster, { "spec": spec })
         )
         sizes = list(self._cloud_session.sizes())
-        return self._from_api_cluster(cluster, sizes)
+        user_id = self._cloud_session.user_id()
+        return self._from_api_cluster(cluster, sizes, user_id)
 
     @convert_exceptions
     def upgrade_cluster(
@@ -514,7 +519,8 @@ class Session:
         ekclusters = self._client.api(AZIMUTH_API_VERSION).resource("clusters")
         cluster = ekclusters.patch(cluster, {"spec": spec})
         sizes = list(self._cloud_session.sizes())
-        return self._from_api_cluster(cluster, sizes)
+        user_id = self._cloud_session.user_id()
+        return self._from_api_cluster(cluster, sizes, user_id)
 
     @convert_exceptions
     def delete_cluster(

--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -505,6 +505,7 @@ class Session:
         if not isinstance(template, dto.ClusterTemplate):
             template = self.find_cluster_template(template)
 
+        # note who triggered the upgrade
         spec = {"templateName": template.id}
         spec["updatedByUsername"] = self._cloud_session.username()
         spec["updatedByUserId"]: self._cloud_session.user_id()

--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -196,7 +196,7 @@ class Session:
                 .fetch(id)
         )
 
-    def _from_api_cluster(self, cluster, sizes, user_id):
+    def _from_api_cluster(self, cluster, sizes):
         """
         Converts a cluster from the Kubernetes API to a DTO.
         """
@@ -304,7 +304,6 @@ class Session:
             cluster.spec.get("createdByUserId"),
             cluster.spec.get("updatedByUsername"),
             cluster.spec.get("updatedByUserId"),
-            cluster.spec.get("createdByUserId") == user_id,
         )
 
     @convert_exceptions
@@ -322,8 +321,7 @@ class Session:
         self._log("Found %s clusters", len(clusters))
         if clusters:
             sizes = list(self._cloud_session.sizes())
-            user_id = self._cloud_session.user_id()
-            return tuple(self._from_api_cluster(c, sizes, user_id) for c in clusters)
+            return tuple(self._from_api_cluster(c, sizes) for c in clusters)
         else:
             return ()
 
@@ -340,8 +338,7 @@ class Session:
                 .fetch(id)
         )
         sizes = list(self._cloud_session.sizes())
-        user_id = self._cloud_session.user_id()
-        return self._from_api_cluster(cluster, sizes, user_id)
+        return self._from_api_cluster(cluster, sizes)
 
     def _create_credential(self, cluster_name):
         """
@@ -475,8 +472,7 @@ class Session:
         })
         # Use the sizes that we already have
         sizes = [control_plane_size] + [ng["machine_size"] for ng in node_groups]
-        user_id = self._cloud_session.user_id()
-        return self._from_api_cluster(cluster, sizes, user_id)
+        return self._from_api_cluster(cluster, sizes)
 
     @convert_exceptions
     def update_cluster(self, cluster: t.Union[dto.Cluster, str], **options):
@@ -493,8 +489,7 @@ class Session:
                 .patch(cluster, { "spec": spec })
         )
         sizes = list(self._cloud_session.sizes())
-        user_id = self._cloud_session.user_id()
-        return self._from_api_cluster(cluster, sizes, user_id)
+        return self._from_api_cluster(cluster, sizes)
 
     @convert_exceptions
     def upgrade_cluster(
@@ -519,8 +514,7 @@ class Session:
         ekclusters = self._client.api(AZIMUTH_API_VERSION).resource("clusters")
         cluster = ekclusters.patch(cluster, {"spec": spec})
         sizes = list(self._cloud_session.sizes())
-        user_id = self._cloud_session.user_id()
-        return self._from_api_cluster(cluster, sizes, user_id)
+        return self._from_api_cluster(cluster, sizes)
 
     @convert_exceptions
     def delete_cluster(

--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -304,6 +304,7 @@ class Session:
             cluster.spec.get("createdByUserId"),
             cluster.spec.get("updatedByUsername"),
             cluster.spec.get("updatedByUserId"),
+            cluster.spec.get("createdByUserId") == user_id,
         )
 
     @convert_exceptions

--- a/api/azimuth/cluster_api/base.py
+++ b/api/azimuth/cluster_api/base.py
@@ -300,6 +300,10 @@ class Session:
                 for name, service in cluster_status.get("services", {}).items()
             ],
             dateutil.parser.parse(cluster.metadata["creationTimestamp"]),
+            cluster.spec.get("createdByUsername"),
+            cluster.spec.get("createdByUserId"),
+            cluster.spec.get("updatedByUsername"),
+            cluster.spec.get("updatedByUserId"),
         )
 
     @convert_exceptions
@@ -450,6 +454,8 @@ class Session:
             "label": name,
             "templateName": template.id,
             "cloudCredentialsSecretName": secret.metadata.name,
+            "createdByUsername": self._cloud_session.username(),
+            "createdByUserId": self._cloud_session.user_id(),
         })
         if zenith_identity_realm_name:
             cluster_spec["zenithIdentityRealmName"] = zenith_identity_realm_name
@@ -474,6 +480,8 @@ class Session:
         Update the specified cluster with the given parameters.
         """
         spec = self._build_cluster_spec(**options)
+        spec["updatedByUsername"] = self._cloud_session.username()
+        spec["updatedByUserId"]: self._cloud_session.user_id()
         cluster = (
             self._client
                 .api(AZIMUTH_API_VERSION)
@@ -496,16 +504,14 @@ class Session:
             cluster = cluster.id
         if not isinstance(template, dto.ClusterTemplate):
             template = self.find_cluster_template(template)
+
+        spec = {"templateName": template.id}
+        spec["updatedByUsername"] = self._cloud_session.username()
+        spec["updatedByUserId"]: self._cloud_session.user_id()
+
         # Apply a patch to the specified cluster to update the template
         ekclusters = self._client.api(AZIMUTH_API_VERSION).resource("clusters")
-        cluster = ekclusters.patch(
-            cluster,
-            {
-                "spec": {
-                    "templateName": template.id,
-                },
-            }
-        )
+        cluster = ekclusters.patch(cluster, {"spec": spec})
         sizes = list(self._cloud_session.sizes())
         return self._from_api_cluster(cluster, sizes)
 

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -133,6 +133,11 @@ class Cluster:
     services: t.List[Service]
     #: The time at which the cluster was created
     created_at: datetime.datetime
+    #: Details about the users interacting with the cluster
+    created_by_username: Optional[str] = None
+    created_by_user_id: Optional[str] = None
+    updated_by_username: Optional[str] = None
+    updated_by_user_id: Optional[str] = None
 
 
 @dataclasses.dataclass(frozen = True)

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -134,10 +134,10 @@ class Cluster:
     #: The time at which the cluster was created
     created_at: datetime.datetime
     #: Details about the users interacting with the cluster
-    created_by_username: Optional[str] = None
-    created_by_user_id: Optional[str] = None
-    updated_by_username: Optional[str] = None
-    updated_by_user_id: Optional[str] = None
+    created_by_username: t.Optional[str]
+    created_by_user_id: t.Optional[str]
+    updated_by_username: t.Optional[str]
+    updated_by_user_id: t.Optional[str]
 
 
 @dataclasses.dataclass(frozen = True)

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -138,6 +138,7 @@ class Cluster:
     created_by_user_id: t.Optional[str]
     updated_by_username: t.Optional[str]
     updated_by_user_id: t.Optional[str]
+    is_mine: bool
 
 
 @dataclasses.dataclass(frozen = True)

--- a/api/azimuth/cluster_api/dto.py
+++ b/api/azimuth/cluster_api/dto.py
@@ -138,7 +138,6 @@ class Cluster:
     created_by_user_id: t.Optional[str]
     updated_by_username: t.Optional[str]
     updated_by_user_id: t.Optional[str]
-    is_mine: bool
 
 
 @dataclasses.dataclass(frozen = True)

--- a/api/azimuth/cluster_engine/drivers/crd/driver.py
+++ b/api/azimuth/cluster_engine/drivers/crd/driver.py
@@ -123,7 +123,6 @@ def get_cluster_dto(raw_cluster, user_id, status_if_ready: dto.ClusterStatus = N
         created_by_user_id=raw_cluster.spec.get("createdByUserId"),
         updated_by_username=raw_cluster.spec.get("updatedByUsername"),
         updated_by_user_id=raw_cluster.spec.get("updatedByUserId"),
-        is_mine=(raw_cluster.spec.get("createdByUserId")==user_id),
     )
 
 

--- a/api/azimuth/cluster_engine/drivers/crd/driver.py
+++ b/api/azimuth/cluster_engine/drivers/crd/driver.py
@@ -123,6 +123,7 @@ def get_cluster_dto(raw_cluster, user_id, status_if_ready: dto.ClusterStatus = N
         created_by_user_id=raw_cluster.spec.get("createdByUserId"),
         updated_by_username=raw_cluster.spec.get("updatedByUsername"),
         updated_by_user_id=raw_cluster.spec.get("updatedByUserId"),
+        is_mine=(raw_cluster.spec.get("createdByUserId")==user_id),
     )
 
 

--- a/api/azimuth/cluster_engine/drivers/crd/driver.py
+++ b/api/azimuth/cluster_engine/drivers/crd/driver.py
@@ -119,10 +119,10 @@ def get_cluster_dto(raw_cluster, status_if_ready: dto.ClusterStatus = None):
         updated=updated_at,
         patched=None,
         services=[],
-        createdByUsername=raw_cluster.spec.get("createdByUsername"),
-        createdByUserId=raw_cluster.spec.get("createdByUserId"),
-        updatedByUsername=raw_cluster.spec.get("updatedByUsername"),
-        updatedByUserId=raw_cluster.spec.get("updatedByUserId"),
+        created_by_username=raw_cluster.spec.get("createdByUsername"),
+        created_by_user_id=raw_cluster.spec.get("createdByUserId"),
+        updated_by_username=raw_cluster.spec.get("updatedByUsername"),
+        updated_by_user_id=raw_cluster.spec.get("updatedByUserId"),
     )
 
 

--- a/api/azimuth/cluster_engine/drivers/crd/driver.py
+++ b/api/azimuth/cluster_engine/drivers/crd/driver.py
@@ -68,7 +68,7 @@ def get_cluster_types(client) -> t.Iterable[dto.ClusterType]:
     return cluster_types
 
 
-def get_cluster_dto(raw_cluster, user_id, status_if_ready: dto.ClusterStatus = None):
+def get_cluster_dto(raw_cluster, status_if_ready: dto.ClusterStatus = None):
     raw_status = raw_cluster.get("status", {})
     status = dto.ClusterStatus.CONFIGURING
     task = None
@@ -123,15 +123,14 @@ def get_cluster_dto(raw_cluster, user_id, status_if_ready: dto.ClusterStatus = N
         created_by_user_id=raw_cluster.spec.get("createdByUserId"),
         updated_by_username=raw_cluster.spec.get("updatedByUsername"),
         updated_by_user_id=raw_cluster.spec.get("updatedByUserId"),
-        is_mine=(raw_cluster.spec.get("createdByUserId")==user_id),
     )
 
 
-def get_clusters(client, ctx: dto.Context) -> t.Iterable[dto.Cluster]:
+def get_clusters(client) -> t.Iterable[dto.Cluster]:
     raw_clusters = list(client.api(CAAS_API_VERSION).resource("clusters").list())
     clusters = []
     for raw_cluster in raw_clusters:
-        cluster = get_cluster_dto(raw_cluster, ctx.user_id)
+        cluster = get_cluster_dto(raw_cluster)
         clusters.append(cluster)
     return clusters
 
@@ -189,10 +188,10 @@ def create_cluster(
             "spec": cluster_spec,
         }
     )
-    return get_cluster_dto(cluster, ctx.user_id)
+    return get_cluster_dto(cluster)
 
 
-def delete_cluster(client, name: str, ctx: dto.Context):
+def delete_cluster(client, name: str):
     safe_name = _escape_name(name)
 
     # TODO(johngarbutt) should we be refreshing the application cred here?
@@ -203,7 +202,7 @@ def delete_cluster(client, name: str, ctx: dto.Context):
     # returning the ready state will confuse people
     time.sleep(0.1)
     raw_cluster = cluster_resource.fetch(safe_name)
-    return get_cluster_dto(raw_cluster,  ctx.user_id, status_if_ready=dto.ClusterStatus.DELETING)
+    return get_cluster_dto(raw_cluster, status_if_ready=dto.ClusterStatus.DELETING)
 
 
 def patch_cluster(client, name: str, ctx: dto.Context):
@@ -249,7 +248,7 @@ def update_cluster(client, name: str, params: t.Mapping[str, t.Any],
     # returning the ready state will confuse people
     time.sleep(0.1)
     raw_cluster = cluster_resource.fetch(safe_name)
-    return get_cluster_dto(raw_cluster,  ctx.user_id, status_if_ready=dto.ClusterStatus.CONFIGURING)
+    return get_cluster_dto(raw_cluster, status_if_ready=dto.ClusterStatus.CONFIGURING)
 
 
 # TODO(johngarbutt) horrible testing hack!
@@ -300,7 +299,7 @@ class Driver(base.Driver):
         List the clusters that are deployed.
         """
         client = get_k8s_client(ctx.tenancy.id)
-        return get_clusters(client, ctx)
+        return get_clusters(client)
 
     def find_cluster(self, id: str, ctx: dto.Context) -> dto.Cluster:
         """
@@ -354,4 +353,4 @@ class Driver(base.Driver):
         Deletes an existing cluster.
         """
         client = get_k8s_client(ctx.tenancy.id)
-        return delete_cluster(client, cluster.name, ctx)
+        return delete_cluster(client, cluster.name)

--- a/api/azimuth/cluster_engine/dto.py
+++ b/api/azimuth/cluster_engine/dto.py
@@ -23,6 +23,8 @@ class Context:
     """
     #: The username of the user carrying out the operation
     username: str
+    #: The user id of the user carrying out the operation
+    user_id: str
     #: The tenancy that the operation is being carried out in
     tenancy: cloud_dto.Tenancy
     #: The cloud credential associated with the operation
@@ -239,3 +241,8 @@ class Cluster:
     patched: datetime
     #: A list of Zenith services enabled for the cluster
     services: Sequence[ClusterService] = field(default_factory = list)
+    #: Details about the users interacting with the cluster
+    createdByUsername: Optional[str] = None
+    createdByUserId: Optional[str] = None
+    updatedByUsername: Optional[str] = None
+    updatedByUserId: Optional[str] = None

--- a/api/azimuth/cluster_engine/dto.py
+++ b/api/azimuth/cluster_engine/dto.py
@@ -239,10 +239,10 @@ class Cluster:
     updated: datetime
     #: The datetime at which the cluster was last patched
     patched: datetime
+    #: Details about the users interacting with the cluster
+    created_by_username: Optional[str]
+    created_by_user_id: Optional[str]
+    updated_by_username: Optional[str]
+    updated_by_user_id: Optional[str]
     #: A list of Zenith services enabled for the cluster
     services: Sequence[ClusterService] = field(default_factory = list)
-    #: Details about the users interacting with the cluster
-    created_by_username: Optional[str] = None
-    created_by_user_id: Optional[str] = None
-    updated_by_username: Optional[str] = None
-    updated_by_user_id: Optional[str] = None

--- a/api/azimuth/cluster_engine/dto.py
+++ b/api/azimuth/cluster_engine/dto.py
@@ -242,7 +242,7 @@ class Cluster:
     #: A list of Zenith services enabled for the cluster
     services: Sequence[ClusterService] = field(default_factory = list)
     #: Details about the users interacting with the cluster
-    createdByUsername: Optional[str] = None
-    createdByUserId: Optional[str] = None
-    updatedByUsername: Optional[str] = None
-    updatedByUserId: Optional[str] = None
+    created_by_username: Optional[str] = None
+    created_by_user_id: Optional[str] = None
+    updated_by_username: Optional[str] = None
+    updated_by_user_id: Optional[str] = None

--- a/api/azimuth/cluster_engine/dto.py
+++ b/api/azimuth/cluster_engine/dto.py
@@ -244,5 +244,6 @@ class Cluster:
     created_by_user_id: Optional[str]
     updated_by_username: Optional[str]
     updated_by_user_id: Optional[str]
+    is_mine: bool
     #: A list of Zenith services enabled for the cluster
     services: Sequence[ClusterService] = field(default_factory = list)

--- a/api/azimuth/cluster_engine/dto.py
+++ b/api/azimuth/cluster_engine/dto.py
@@ -244,6 +244,5 @@ class Cluster:
     created_by_user_id: Optional[str]
     updated_by_username: Optional[str]
     updated_by_user_id: Optional[str]
-    is_mine: bool
     #: A list of Zenith services enabled for the cluster
     services: Sequence[ClusterService] = field(default_factory = list)

--- a/api/azimuth/provider/base.py
+++ b/api/azimuth/provider/base.py
@@ -120,6 +120,12 @@ class ScopedSession:
     """
     Class for a tenancy-scoped session.
     """
+    def user_id(self) -> str:
+        """
+        Returns the username for this session.
+        """
+        raise NotImplementedError
+
     def username(self) -> str:
         """
         Returns the username for this session.

--- a/api/azimuth/provider/openstack/provider.py
+++ b/api/azimuth/provider/openstack/provider.py
@@ -420,6 +420,12 @@ class ScopedSession(base.ScopedSession):
             self._username, self._tenancy.name, *args, **kwargs
         )
 
+    def user_id(self) -> str:
+        """
+        See :py:meth:`.base.ScopedSession.user_id`.
+        """
+        return self._connection.user_id
+
     def username(self):
         """
         See :py:meth:`.base.ScopedSession.username`.

--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -346,7 +346,6 @@
     border-bottom: 1px solid var(--bs-gray-300) !important;
 }
 
-
 /**
  * Custom styles for quota cards.
  */

--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -345,7 +345,9 @@
 .platform-type-card .card-title {
     border-bottom: 1px solid var(--bs-gray-300) !important;
 }
-
+.badge {
+    margin-left: 5px
+}
 
 /**
  * Custom styles for quota cards.

--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -346,6 +346,7 @@
     border-bottom: 1px solid var(--bs-gray-300) !important;
 }
 
+
 /**
  * Custom styles for quota cards.
  */

--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -345,6 +345,9 @@
 .platform-type-card .card-title {
     border-bottom: 1px solid var(--bs-gray-300) !important;
 }
+.badge {
+    margin-left: 5px
+}
 
 /**
  * Custom styles for quota cards.

--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -345,9 +345,7 @@
 .platform-type-card .card-title {
     border-bottom: 1px solid var(--bs-gray-300) !important;
 }
-.badge {
-    margin-left: 5px
-}
+
 
 /**
  * Custom styles for quota cards.

--- a/ui/assets/tweaks.css
+++ b/ui/assets/tweaks.css
@@ -345,9 +345,6 @@
 .platform-type-card .card-title {
     border-bottom: 1px solid var(--bs-gray-300) !important;
 }
-.badge {
-    margin-left: 5px
-}
 
 /**
  * Custom styles for quota cards.

--- a/ui/src/components/pages/tenancy/platforms/clusters/card.js
+++ b/ui/src/components/pages/tenancy/platforms/clusters/card.js
@@ -415,6 +415,9 @@ export const ClusterCard = ({
     return (
         <Card className="platform-card">
             <Card.Header>
+	        {cluster.is_mine && (
+                <Badge bg='primary'>YOURS</Badge>
+		)}
                 <Badge bg={statusBadgeBg[cluster.status]}>{cluster.status}</Badge>
             </Card.Header>
             <Card.Img src={clusterType.logo} />

--- a/ui/src/components/pages/tenancy/platforms/clusters/card.js
+++ b/ui/src/components/pages/tenancy/platforms/clusters/card.js
@@ -411,7 +411,6 @@ export const ClusterCard = ({
     tenancyActions
 }) => {
     const clusterType = clusterTypes.data[cluster.cluster_type];
-    const updatedAt = cluster.updated || cluster.created;
     return (
         <Card className="platform-card">
             <Card.Header>
@@ -431,7 +430,8 @@ export const ClusterCard = ({
                 </Card.Body>
             )}
             <Card.Body className="small text-muted">
-                Updated {updatedAt.toRelative()}
+                Created {cluster.created.toRelative()}<br/>
+                Created by {cluster.created_by_username ? cluster.created_by_username : '-'}
             </Card.Body>
             <Card.Footer>
                 <ClusterDetailsButton

--- a/ui/src/components/pages/tenancy/platforms/clusters/card.js
+++ b/ui/src/components/pages/tenancy/platforms/clusters/card.js
@@ -415,9 +415,6 @@ export const ClusterCard = ({
     return (
         <Card className="platform-card">
             <Card.Header>
-	        {cluster.is_mine && (
-                <Badge bg='primary'>YOURS</Badge>
-		)}
                 <Badge bg={statusBadgeBg[cluster.status]}>{cluster.status}</Badge>
             </Card.Header>
             <Card.Img src={clusterType.logo} />

--- a/ui/src/components/pages/tenancy/platforms/clusters/card.js
+++ b/ui/src/components/pages/tenancy/platforms/clusters/card.js
@@ -166,8 +166,16 @@ const ClusterStatusCard = ({ cluster }) => (
                     <td>{cluster.created.toRelative()}</td>
                 </tr>
                 <tr>
+                    <th>Created by</th>
+                    <td>{cluster.created_by_username ? cluster.created_by_username : '-'}</td>
+                </tr>
+                <tr>
                     <th>Updated</th>
                     <td>{cluster.updated ? cluster.updated.toRelative() : '-'}</td>
+                </tr>
+                <tr>
+                    <th>Updated by</th>
+                    <td>{cluster.updated_by_username ? cluster.updated_by_username : '-'}</td>
                 </tr>
                 <tr>
                     <th>Patched</th>

--- a/ui/src/components/pages/tenancy/platforms/clusters/card.js
+++ b/ui/src/components/pages/tenancy/platforms/clusters/card.js
@@ -167,7 +167,7 @@ const ClusterStatusCard = ({ cluster }) => (
                 </tr>
                 <tr>
                     <th>Created by</th>
-                    <td>{cluster.created_by_username ? cluster.created_by_username : '-'}</td>
+                    <td>{cluster.created_by_username || '-'}</td>
                 </tr>
                 <tr>
                     <th>Updated</th>
@@ -175,7 +175,7 @@ const ClusterStatusCard = ({ cluster }) => (
                 </tr>
                 <tr>
                     <th>Updated by</th>
-                    <td>{cluster.updated_by_username ? cluster.updated_by_username : '-'}</td>
+                    <td>{cluster.updated_by_username || '-'}</td>
                 </tr>
                 <tr>
                     <th>Patched</th>

--- a/ui/src/components/pages/tenancy/platforms/clusters/card.js
+++ b/ui/src/components/pages/tenancy/platforms/clusters/card.js
@@ -431,7 +431,7 @@ export const ClusterCard = ({
             )}
             <Card.Body className="small text-muted">
                 Created {cluster.created.toRelative()}<br/>
-                Created by {cluster.created_by_username ? cluster.created_by_username : '-'}
+                Created by {cluster.created_by_username || 'unknown'}
             </Card.Body>
             <Card.Footer>
                 <ClusterDetailsButton

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -692,6 +692,9 @@ export const KubernetesCard = ({
     return (
         <Card className="platform-card">
             <Card.Header>
+                {kubernetesCluster.is_mine && (
+                <Badge bg='primary'>YOURS</Badge>
+                )}
                 <Badge bg={statusBadgeBg[kubernetesCluster.status]}>
                     {kubernetesCluster.status.toUpperCase()}
                 </Badge>

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -707,7 +707,8 @@ export const KubernetesCard = ({
                 />
             )}
             <Card.Body className="small text-muted">
-                Created {kubernetesCluster.created_at.toRelative()}
+                Created {kubernetesCluster.created_at.toRelative()}<br/>
+                Created by {kubernetesCluster.created_by_username ? kubernetesCluster.created_by_username : '-'}
             </Card.Body>
             <Card.Footer>
                 <KubernetesClusterDetailsButton

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -692,9 +692,6 @@ export const KubernetesCard = ({
     return (
         <Card className="platform-card">
             <Card.Header>
-                {kubernetesCluster.is_mine && (
-                <Badge bg='primary'>YOURS</Badge>
-                )}
                 <Badge bg={statusBadgeBg[kubernetesCluster.status]}>
                     {kubernetesCluster.status.toUpperCase()}
                 </Badge>

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -298,11 +298,11 @@ const ClusterOverviewCard = ({ kubernetesCluster, kubernetesClusterTemplates }) 
                     <th>Created</th>
                     <td>{kubernetesCluster.created_at.toRelative()}</td>
                 </tr>
-                <tr>
+	        <tr>
                     <th>Created by</th>
                     <td>{kubernetesCluster.created_by_username ? kubernetesCluster.created_by_username : '-'}</td>
                 </tr>
-                <tr>
+	        <tr>
                     <th>Updated by</th>
                     <td>{kubernetesCluster.updated_by_username ? kubernetesCluster.updated_by_username : '-'}</td>
                 </tr>

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -708,7 +708,7 @@ export const KubernetesCard = ({
             )}
             <Card.Body className="small text-muted">
                 Created {kubernetesCluster.created_at.toRelative()}<br/>
-                Created by {kubernetesCluster.created_by_username ? kubernetesCluster.created_by_username : '-'}
+                Created by {cluster.created_by_username || 'unknown'}
             </Card.Body>
             <Card.Footer>
                 <KubernetesClusterDetailsButton

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -300,11 +300,11 @@ const ClusterOverviewCard = ({ kubernetesCluster, kubernetesClusterTemplates }) 
                 </tr>
                 <tr>
                     <th>Created by</th>
-                    <td>{kubernetesCluster.created_by_username ? kubernetesCluster.created_by_username : '-'}</td>
+                    <td>{kubernetesCluster.created_by_username || '-'}</td>
                 </tr>
                 <tr>
                     <th>Updated by</th>
-                    <td>{kubernetesCluster.updated_by_username ? kubernetesCluster.updated_by_username : '-'}</td>
+                    <td>{kubernetesCluster.updated_by_username || '-'}</td>
                 </tr>
             </tbody>
         </Table>

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -298,11 +298,11 @@ const ClusterOverviewCard = ({ kubernetesCluster, kubernetesClusterTemplates }) 
                     <th>Created</th>
                     <td>{kubernetesCluster.created_at.toRelative()}</td>
                 </tr>
-	        <tr>
+                <tr>
                     <th>Created by</th>
                     <td>{kubernetesCluster.created_by_username ? kubernetesCluster.created_by_username : '-'}</td>
                 </tr>
-	        <tr>
+                <tr>
                     <th>Updated by</th>
                     <td>{kubernetesCluster.updated_by_username ? kubernetesCluster.updated_by_username : '-'}</td>
                 </tr>

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -298,6 +298,14 @@ const ClusterOverviewCard = ({ kubernetesCluster, kubernetesClusterTemplates }) 
                     <th>Created</th>
                     <td>{kubernetesCluster.created_at.toRelative()}</td>
                 </tr>
+	        <tr>
+                    <th>Created by</th>
+                    <td>{kubernetesCluster.created_by_username ? kubernetesCluster.created_by_username : '-'}</td>
+                </tr>
+	        <tr>
+                    <th>Updated by</th>
+                    <td>{kubernetesCluster.updated_by_username ? kubernetesCluster.updated_by_username : '-'}</td>
+                </tr>
             </tbody>
         </Table>
     </Card>


### PR DESCRIPTION
Make the API show who created any updated both
CaaS clusters and K8s clusters.

This depends on the CRD changes here:
https://github.com/stackhpc/azimuth-caas-operator/pull/89
https://github.com/stackhpc/azimuth-capi-operator/pull/105