### PR TITLE
Fix platform cleanup for CaaS clusters

### DIFF
--- a/api/azimuth/identity.py
+++ b/api/azimuth/identity.py
@@ -115,6 +115,15 @@ def ensure_platform_for_cluster(
                     "labels": {
                         "app.kubernetes.io/managed-by": "azimuth",
                     },
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "caas.azimuth.stackhpc.com/v1alpha1",
+                            "kind": "Cluster",
+                            "name": utils.sanitise(cluster.name),
+                            "uid": cluster.id,
+                            "blockOwnerDeletion": True,
+                        },
+                    ],
                 },
                 "spec": {
                     "realmName": realm.name,
@@ -128,16 +137,4 @@ def ensure_platform_for_cluster(
                 },
             },
             force = True
-        )
-
-
-def remove_platform_for_cluster(tenancy: dto.Tenancy, cluster: cluster_dto.Cluster):
-    """
-    Removes the identity platform for the cluster.
-    """
-    with ekconfig.sync_client(default_field_manager = "azimuth") as client:
-        tenancy_namespace = utils.get_namespace(client, tenancy)
-        client.api(AZIMUTH_IDENTITY_API_VERSION).resource("platforms").delete(
-            f"caas-{utils.sanitise(cluster.name)}",
-            namespace = tenancy_namespace
         )

--- a/api/azimuth/identity.py
+++ b/api/azimuth/identity.py
@@ -1,11 +1,11 @@
 import dataclasses
-import re
 import typing as t
 
 from easykube import Configuration, ApiError
 
 from .cluster_engine import dto as cluster_dto
 from .provider import dto
+from . import utils
 
 
 AZIMUTH_IDENTITY_API_VERSION = "identity.azimuth.stackhpc.com/v1alpha1"
@@ -13,13 +13,6 @@ AZIMUTH_IDENTITY_API_VERSION = "identity.azimuth.stackhpc.com/v1alpha1"
 
 # Configure the Kubernetes client from the environment
 ekconfig = Configuration.from_environment()
-
-
-def sanitize(value):
-    """
-    Returns a sanitized form of the given value suitable for Kubernetes resource names.
-    """
-    return re.sub("[^a-z0-9]+", "-", str(value).lower()).strip("-")
 
 
 @dataclasses.dataclass(frozen = True)
@@ -54,12 +47,12 @@ def get_realm(tenancy: dto.Tenancy) -> t.Optional[Realm]:
     """
     Returns the identity realm for the tenancy.
     """
-    sanitized_tenancy_name = sanitize(tenancy.name)
     with ekconfig.sync_client() as client:
+        tenancy_namespace = utils.get_namespace(client, tenancy)
         try:
             realm = client.api(AZIMUTH_IDENTITY_API_VERSION).resource("realms").fetch(
-                f"az-{sanitized_tenancy_name}",
-                namespace = f"az-{sanitized_tenancy_name}"
+                tenancy_namespace,
+                namespace = tenancy_namespace
             )
         except ApiError as exc:
             if exc.status_code == 404:
@@ -74,31 +67,21 @@ def ensure_realm(tenancy: dto.Tenancy) -> Realm:
     """
     Ensures that an identity realm exists for the given tenancy.
     """
-    sanitized_tenancy_name = sanitize(tenancy.name)
-    namespace = f"az-{sanitized_tenancy_name}"
     with ekconfig.sync_client(default_field_manager = "azimuth") as client:
+        tenancy_namespace = utils.get_namespace(client, tenancy)
         # Create the namespace if required
-        try:
-            client.api("v1").resource("namespaces").create({
-                "metadata": {
-                    "name": namespace,
-                    "labels": {
-                        "app.kubernetes.io/managed-by": "azimuth",
-                    },
-                },
-            })
-        except ApiError as exc:
-            # Swallow the conflict that occurs when the namespace already exists
-            if exc.status_code != 409 or exc.reason.lower() != "alreadyexists":
-                raise
-        # Then create the realm
+        utils.ensure_namespace(client, tenancy_namespace, tenancy)
+        # We create a realm with the same name as the tenancy namespace
+        # This means that we don't get a realm name of the format {namespace}-{name}
+        # because in the case where the namespace and name are identical, the identity
+        # operator reduces that to just {name}
         realm = client.apply_object(
             {
                 "apiVersion": AZIMUTH_IDENTITY_API_VERSION,
                 "kind": "Realm",
                 "metadata": {
-                    "name": f"az-{sanitized_tenancy_name}",
-                    "namespace": namespace,
+                    "name": tenancy_namespace,
+                    "namespace": tenancy_namespace,
                     "labels": {
                         "app.kubernetes.io/managed-by": "azimuth",
                     },
@@ -120,16 +103,15 @@ def ensure_platform_for_cluster(
     """
     Ensures that an identity platform exists for the cluster.
     """
-    sanitized_name = sanitize(cluster.name)
-    sanitized_tenancy_name = sanitize(tenancy.name)
     with ekconfig.sync_client(default_field_manager = "azimuth") as client:
+        tenancy_namespace = utils.get_namespace(client, tenancy)
         client.apply_object(
             {
                 "apiVersion": AZIMUTH_IDENTITY_API_VERSION,
                 "kind": "Platform",
                 "metadata": {
-                    "name": f"caas-{sanitized_name}",
-                    "namespace": f"az-{sanitized_tenancy_name}",
+                    "name": f"caas-{utils.sanitise(cluster.name)}",
+                    "namespace": tenancy_namespace,
                     "labels": {
                         "app.kubernetes.io/managed-by": "azimuth",
                     },
@@ -153,10 +135,9 @@ def remove_platform_for_cluster(tenancy: dto.Tenancy, cluster: cluster_dto.Clust
     """
     Removes the identity platform for the cluster.
     """
-    sanitized_name = sanitize(cluster.name)
-    sanitized_tenancy_name = sanitize(tenancy.name)
     with ekconfig.sync_client(default_field_manager = "azimuth") as client:
+        tenancy_namespace = utils.get_namespace(client, tenancy)
         client.api(AZIMUTH_IDENTITY_API_VERSION).resource("platforms").delete(
-            f"caas-{sanitized_name}",
-            namespace = f"az-{sanitized_tenancy_name}"
+            f"caas-{utils.sanitise(cluster.name)}",
+            namespace = tenancy_namespace
         )

--- a/api/azimuth/utils.py
+++ b/api/azimuth/utils.py
@@ -1,0 +1,94 @@
+import logging
+import re
+
+import easykube
+
+from .provider import dto
+
+
+MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+TENANCY_ID_LABEL = "azimuth.stackhpc.com/tenant-id"
+
+
+logger = logging.getLogger(__name__)
+
+
+class NamespaceOwnershipError(Exception):
+    """
+    Raised when there is a conflict in the namespace ownership.
+    """
+    def __init__(self, namespace: str, expected_owner: str, current_owner: str):
+        super().__init__(
+            f"expected namespace '{namespace}' to be owned by tenant "
+            f"'{expected_owner}' but found '{current_owner}'"
+        )
+
+
+def sanitise(value):
+    """
+    Returns a sanitised form of the given value suitable for Kubernetes resource names.
+    """
+    return re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+
+
+def get_namespace(ekclient, tenancy: dto.Tenancy) -> str:
+    """
+    Returns the correct namespace to use for the given tenancy.
+    """
+    tenancy_id = sanitise(tenancy.id)
+    tenancy_name = sanitise(tenancy.name)
+    ekresource = ekclient.api("v1").resource("namespaces")
+    expected_namespace = f"az-{tenancy_name}"
+    # Try to find the namespace that is labelled with the tenant ID
+    try:
+        namespace = next(ekresource.list(labels = {TENANCY_ID_LABEL: tenancy_id}))
+    except StopIteration:
+        pass
+    else:
+        found_namespace = namespace["metadata"]["name"]
+        logger.info(f"using namespace '{found_namespace}' for tenant '{tenancy_id}'")
+        if found_namespace != expected_namespace:
+            logger.warn(
+                f"expected namespace '{expected_namespace}' for "
+                f"tenant '{tenancy_id}', but found '{found_namespace}'"
+            )
+        return found_namespace
+    # If there is no namespace labelled with the tenant ID, find the namespace
+    # that uses the standard naming convention
+    try:
+        namespace = ekresource.fetch(expected_namespace)
+    except easykube.ApiError as exc:
+        if exc.status_code == 404:
+            # Even if the namespace doesn't exist, it is still the correct one to use
+            logger.info(f"using namespace '{expected_namespace}' for tenant '{tenancy_id}'")
+            return expected_namespace
+        else:
+            raise
+    # Before returning it, verify that it isn't labelled with another tenancy ID
+    owner_id = namespace["metadata"].get("labels", {}).get(TENANCY_ID_LABEL)
+    if not owner_id or owner_id == tenancy_id:
+        logger.info(f"using namespace '{expected_namespace}' for tenant '{tenancy_id}'")
+        return expected_namespace
+    else:
+        raise NamespaceOwnershipError(expected_namespace, tenancy_id, owner_id)
+
+
+def ensure_namespace(ekclient, namespace: str, tenancy: dto.Tenancy):
+    """
+    Ensures that the specified namespace exists and is labelled correctly for
+    the specified tenancy.
+
+    Assumes that the namespace name was discovered using ``get_namespace``.
+    """
+    # First try to patch the namespace to add the label
+    ekclient.api("v1").resource("namespaces").create_or_patch(
+        namespace,
+        {
+            "metadata": {
+                "labels": {
+                    MANAGED_BY_LABEL: "azimuth",
+                    TENANCY_ID_LABEL: sanitise(tenancy.id),
+                },
+            },
+        }
+    )

--- a/api/azimuth/views.py
+++ b/api/azimuth/views.py
@@ -1206,8 +1206,6 @@ def cluster_details(request, tenant, cluster):
                 )
                 return response.Response(output_serializer.data)
             elif request.method == "DELETE":
-                if cloud_settings.APPS:
-                    identity.remove_platform_for_cluster(session.tenancy(), cluster)
                 deleted = cluster_manager.delete_cluster(cluster)
                 if deleted:
                     serializer = serializers.ClusterSerializer(

--- a/chart/templates/api/clusterrole.yaml
+++ b/chart/templates/api/clusterrole.yaml
@@ -51,7 +51,10 @@ rules:
     resources:
       - namespaces
     verbs:
+      - list
+      - get
       - create
+      - patch
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Identity platforms are not explicitly linked to CaaS clusters via ownership, like they are for the Kubernetes side. This can lead to situations where a cluster is deleted but the identity platform is left behind. This causes alerts about the missing Zenith services until the platform is manually removed. This is especially an issue when using the auto-delete functionality, but can also cause issues when the identity platform is not cleanly removed.

The solution is to create CaaS clusters in the same namespace as the identity platform resources so that proper owner references can be used to clean up the associated platform when a CaaS cluster is deleted. Protections are put in place to make sure that namespaces cannot be stomped on when projects change name etc.