### PR TITLE
Make token auth data parsing more robust

### DIFF
--- a/api/azimuth_auth/views.py
+++ b/api/azimuth_auth/views.py
@@ -2,7 +2,6 @@
 Views for the Azimuth auth package.
 """
 
-import json
 import unicodedata
 from urllib.parse import urlparse, urlencode
 
@@ -301,8 +300,8 @@ def token(request, authenticator):
         )
     # Try to pass the authentication data from the request
     try:
-        auth_data = json.loads(request.body)
-    except json.JSONDecodeError:
+        auth_data = request.POST.dict()
+    except Exception:
         return JsonResponse(
             { "message": "Request does not contain valid JSON." },
             status = 400


### PR DESCRIPTION
The Django docs [recommend](https://docs.djangoproject.com/en/5.0/ref/request-response/#django.http.HttpRequest.body) using `HttpRequest.POST.dict()` to parse form data rather than reading the request body directly. The current implementation which reads the body directly fails when incoming requests are made via the JavaScript Fetch API with a [FormData](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#body) instance containing the auth data because the `request.body` content in such cases is a byte string of the form
```
b'------formdata-undici-053294264950\r\nContent-Disposition: form-data; name="application_credential_id"\r\n\r\<redacted>\r\n------formdata-undici-053294264950\r\nContent-Disposition: form-data; name="application_credential_secret"\r\n\r\<redacted>\r\n------formdata-undici-053294264950--'
```
which `json.loads` cannot parse. Using `request.POST.dict()` fixes the issue.