### PR TITLE
Fix size lookup when a flavor has been deleted

### DIFF
--- a/ui/src/components/pages/tenancy/machines/table.js
+++ b/ui/src/components/pages/tenancy/machines/table.js
@@ -193,7 +193,7 @@ const MachineRow = ({
             <td className="text-wrap">{machine.name}</td>
             {/* Allow long image names to wrap */}
             <td className="text-wrap">{get(machine.image, 'name', '-')}</td>
-            <td><MachineSizeLink sizes={sizes} sizeId={machine.size.id} /></td>
+            <td><MachineSizeLink sizes={sizes} size={machine.size} /></td>
             <td><MachineStatus machine={machine} /></td>
             <td>{machine.power_state}</td>
             <td>

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/card.js
@@ -341,7 +341,7 @@ const ControlPlaneCard = ({ kubernetesCluster, sizes }) => (
                     <td>
                         <MachineSizeLink
                             sizes={sizes}
-                            sizeId={kubernetesCluster.control_plane_size.id}
+                            size={kubernetesCluster.control_plane_size}
                         />
                     </td>
                 </tr>
@@ -461,7 +461,7 @@ const NodesTable = ({ kubernetesCluster, sizes }) => {
                             />
                         </td>
                         <td>
-                            <MachineSizeLink sizes={sizes} sizeId={node.size.id} />
+                            <MachineSizeLink sizes={sizes} size={node.size} />
                         </td>
                         <td>{node.kubelet_version || '-'}</td>
                         <td>{node.ip || '-'}</td>

--- a/ui/src/components/pages/tenancy/platforms/kubernetes/form.js
+++ b/ui/src/components/pages/tenancy/platforms/kubernetes/form.js
@@ -228,10 +228,10 @@ const initialState = kubernetesCluster => {
         return {
             name: kubernetesCluster.name,
             template: kubernetesCluster.template.id,
-            control_plane_size: kubernetesCluster.control_plane_size.id,
+            control_plane_size: kubernetesCluster.control_plane_size ? kubernetesCluster.control_plane_size.id : "",
             node_groups: kubernetesCluster.node_groups.map(ng => ({
                 name: ng.name,
-                machine_size: ng.machine_size.id,
+                machine_size: ng.machine_size ? ng.machine_size.id : "",
                 autoscale: ng.autoscale,
                 count: ng.count,
                 min_count: ng.min_count,
@@ -536,7 +536,7 @@ export const KubernetesClusterForm = ({
                                             {ng.name}
                                         </td>
                                         <td className="align-middle">
-                                            <MachineSizeLink sizes={sizes} sizeId={ng.machine_size} />
+                                            <MachineSizeLink sizes={sizes} size={ng.machine_size} />
                                         </td>
                                         <td className="align-middle">
                                             {ng.autoscale ? (

--- a/ui/src/components/pages/tenancy/resource-utils.js
+++ b/ui/src/components/pages/tenancy/resource-utils.js
@@ -150,12 +150,13 @@ const MachineSizePopover = ({ children, size, ...props }) => (
 );
 
 
-export const MachineSizeLink = ({ sizes, sizeId }) => {
-    const size = get(sizes.data, sizeId);
-    if( size ) {
+export const MachineSizeLink = ({ sizes, size }) => {
+    const sizeId = size ? size.id : ""
+    const _size = get(sizes.data, sizeId);
+    if( _size ) {
         return (
-            <MachineSizePopover size={size} placement="top">
-                <Button variant="link">{size.name}</Button>
+            <MachineSizePopover size={_size} placement="top">
+                <Button variant="link">{_size.name}</Button>
             </MachineSizePopover>
         );
     }


### PR DESCRIPTION
An instance can be running with a flavor that has since been deleted. When this is the case, the Machines tab will crash with ``TypeError: t.size is null``.

Fix this by replacing ``null`` with an empty object.