### PR TITLE
Error on multiple networks with the same tag

### DIFF
--- a/api/azimuth/provider/openstack/provider.py
+++ b/api/azimuth/provider/openstack/provider.py
@@ -636,7 +636,9 @@ class ScopedSession(base.ScopedSession):
             self._log("Multiple tagged %s networks found.", net_type, level = logging.ERROR)
             # Raise here to avoid creating multiple portal-internal networks
             raise errors.InvalidOperationError(f"Multiple networks tagged {net_type} found.")
-        return networks[0]
+        network = networks[0]
+        self._log("Using tagged %s network '%s'", net_type, network.name)
+        return network
 
     def _templated_network(self, template, net_type):
         """


### PR DESCRIPTION
This helps us be more consistent with CAPO that will error when it looks for portal-internal and sees multiple networks.

Possibly more importantly, it stops surpizes when you accidentally end up with mutiple networks with the same tag, and we end up relying on the order of the networks being returned from the Neutron API's default sort ordering.